### PR TITLE
Update Alpine to 3.12

### DIFF
--- a/dockerfiles/alpine-cloudflare-dyndns/Dockerfile
+++ b/dockerfiles/alpine-cloudflare-dyndns/Dockerfile
@@ -5,7 +5,7 @@
 # Docker:  https://hub.docker.com/u/ellerbrock
 # Quay:    https://quay.io/user/ellerbrock
 
-FROM alpine:3.8
+FROM alpine:3.12
 
 LABEL com.frapsoft.maintainer="Maik Ellerbrock" \
       com.frapsoft.version="0.3.0"


### PR DESCRIPTION
I noticed that Alpine 3.8 has such an old bundle of CA certificates, that curl fails to verify https://api.ipify.org certificate chain:

```
* Rebuilt URL to: https://api.ipify.org/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 23.21.153.210...
* TCP_NODELAY set
* Connected to api.ipify.org (23.21.153.210) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [231 bytes data]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [89 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [5406 bytes data]
* TLSv1.2 (OUT), TLS alert, certificate expired (557):
} [2 bytes data]
* SSL certificate problem: certificate has expired
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

Updating Alpine to latest fixes this. I also tried updating ca-certificates to 3.8 but with no progress. I think updating to Alpine 3.12 is in any way the correct thing.
