### PR TITLE
updated deprecated styles

### DIFF
--- a/dockerfiles/alpine-harden/harden.sh
+++ b/dockerfiles/alpine-harden/harden.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -x
 set -e
 
@@ -35,8 +35,8 @@ find /sbin /usr/sbin ! -type d \
 # Remove world-writable permissions.
 # This breaks apps that need to write to /tmp,
 # such as ssh-agent.
-find / -xdev -type d -perm +0002 -exec chmod o-w {} +
-find / -xdev -type f -perm +0002 -exec chmod o-w {} +
+find / -xdev -type d -perm /0002 -exec chmod o-w {} +
+find / -xdev -type f -perm /0002 -exec chmod o-w {} +
 
 # Remove unnecessary user accounts.
 sed -i -r "/^(${SERVICE_USER}|root|sshd)/!d" /etc/group
@@ -68,7 +68,7 @@ find $sysdirs -xdev -type d \
   -exec chmod 0755 {} \;
 
 # Remove all suid files.
-find $sysdirs -xdev -type f -a -perm +4000 -delete
+find $sysdirs -xdev -type f -a -perm /4000 -delete
 
 # Remove other programs that could be dangerous.
 find $sysdirs -xdev \( \


### PR DESCRIPTION
Ran into couple of errors
- While using `sh`. Cannot recognise `[[`
```
+ [[ -f /etc/ssh/moduli ]]
./harden.sh: 16: [[: not found
```
- Using deprecated `find` flags:
```
+ find / -xdev -type d -perm +0002 -exec chmod o-w {} +
find: invalid mode ‘+0002’
```
```
+ find /bin /etc /lib /sbin /usr -xdev -type f -a -perm +4000 -delete
find: invalid mode ‘+4000’
```

this is happening because `find` has deprecated +mode. From man page of `find`:
![image](https://user-images.githubusercontent.com/42383989/140023455-29f06019-feef-4647-b069-efaf0b8985be.png)
